### PR TITLE
Forbid wrong signature request instead of ignoring

### DIFF
--- a/api/extensions/components/EApiAccessRule.php
+++ b/api/extensions/components/EApiAccessRule.php
@@ -23,31 +23,27 @@ class EApiAccessRule extends CAccessRule
 	 */
 	public function isRequestAllowed($user, $controller, $action, $ip, $verb)
 	{
-
 		if ($this->isActionMatched($action)
 			&& $this->isUserMatched(Yii::app()->user)
 			&& $this->isRoleMatched(Yii::app()->user)
-			&& $this->isSignatureMatched($user)
 			&& $this->isIpMatched($ip)
 			&& $this->isVerbMatched($verb)
 			&& $this->isControllerMatched($controller)
 		)
 		{
-			return $this->allow ? 1 : -1;
+			return ($this->allow && $this->checkSignature($user)) ? 1 : -1;
 		} else
 			return 0;
 	}
 
 	/**
-	 * Checks whether the policy and sig
+	 * Checks signature for the user.
 	 * @param ApiUser $user
 	 * @return bool
 	 * @throws EApiError
 	 */
-	public function isSignatureMatched($user)
+	public function checkSignature($user)
 	{
-
-
 		$requestArray = Yii::app()->getController()->getJsonInputAsArray();
 
 		if (empty($requestArray))
@@ -62,7 +58,6 @@ class EApiAccessRule extends CAccessRule
 
 		if (!$signature || !$expires)
 		{
-
 			throw new EApiError(
 				HHttp::ERROR_BADREQUEST,
 				HHttp::getErrorMessage(HHttp::ERROR_BADREQUEST)

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,6 @@
     "homepage": "http://2amigos.us",
     "type": "yii-application",
     "license": "BSD-3-Clause",
-    "description": "description_text",
     "minimum-stability": "dev",
     "config": {
         "vendor-dir": "common/lib/vendor"


### PR DESCRIPTION
Access rule must restrict access in case if signature is wrong - not just silently ignore.

Also it could be worth looking forward to CAccessRule::isUserAllowed() for better re-usage.