### PR TITLE
Removed redundant row date_default_timezone_set($params['php.timezone'])  in Initializer.php

### DIFF
--- a/common/lib/Yiinitializr/Helpers/Initializer.php
+++ b/common/lib/Yiinitializr/Helpers/Initializer.php
@@ -148,8 +148,6 @@ class Initializer
 		if(isset($params['php.timezone']))
 			date_default_timezone_set($params['php.timezone']);
 
-		date_default_timezone_set($params['php.timezone']);
-
 		if(!class_exists('YiiBase'))
 			require(Config::value('yii.path').'/yii.php');
 	}


### PR DESCRIPTION
Removed redundant row date_default_timezone_set($params['php.timezone']) which cause Undefined index exception if there is no php.timezone in config params.
